### PR TITLE
Env parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "react-dom": "18.2.0",
         "tailwindcss": "3.3.3",
         "typescript": "5.2.2",
-        "xml2js": "^0.6.2"
+        "xml2js": "^0.6.2",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@types/mssql": "^9.1.1",
@@ -3410,6 +3411,14 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/next/node_modules/zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
@@ -4884,9 +4893,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-dom": "18.2.0",
     "tailwindcss": "3.3.3",
     "typescript": "5.2.2",
-    "xml2js": "^0.6.2"
+    "xml2js": "^0.6.2",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/mssql": "^9.1.1",

--- a/src/entities/EmailSender.ts
+++ b/src/entities/EmailSender.ts
@@ -1,3 +1,4 @@
+import config from "@utils/config";
 import nodemailer from "nodemailer";
 
 class EmailSender {
@@ -5,12 +6,13 @@ class EmailSender {
   private readonly DISABLED: boolean = false;
   private readonly ENVIRONMENT: string = "PRODUCTION";
 
-  private readonly SMTP_HOST: any = process.env.SMTP_HOST!;
-  private readonly SMTP_PORT: number = parseInt(process.env.SMTP_PORT!);
+  private readonly SMTP_HOST: string = config.SMTP_HOST;
+  private readonly SMTP_PORT: number = config.SMTP_PORT;
   private readonly TIMEOUT_SECS: number = 30; // Replace with your desired timeout value
-  private readonly DEFAULT_EMAIL: string = process.env.DEFAULT_EMAIL!;
-  private readonly KINGVALE_EMAIL: string = process.env.KINGVALE_EMAIL!;
-  private readonly D3_DISPATCHERS_EMAIL: string = process.env.D3_DISPATCHERS_EMAIL!;
+  private readonly DEFAULT_EMAIL: string = config.DEFAULT_EMAIL;
+  private readonly KINGVALE_EMAIL: string = config.KINGVALE_EMAIL;
+  private readonly D3_DISPATCHERS_EMAIL: string =
+    process.env.D3_DISPATCHERS_EMAIL!;
   private readonly SEND_TO_TEST_LIST: string[] = ["jared.sun@dot.ca.gov"];
   private readonly BCC_RECIPIENTS_LIST: string[] = ["jared.sun@dot.ca.gov"];
 
@@ -55,7 +57,14 @@ class EmailSender {
       bcc: this.BCC_RECIPIENTS_LIST.join(", "),
     };
 
-    console.log("Sending email:", subject, "to", to_email_list.join(", "), "BCC", this.BCC_RECIPIENTS_LIST);
+    console.log(
+      "Sending email:",
+      subject,
+      "to",
+      to_email_list.join(", "),
+      "BCC",
+      this.BCC_RECIPIENTS_LIST
+    );
 
     try {
       const info = await this.transporter.sendMail(mailOptions);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,3 +1,26 @@
+import { z } from "zod";
+
+const configSchema = z.object({
+  SMTP_HOST: z.string().trim().min(1),
+  SMTP_PORT: z.coerce.number().int().positive(),
+  DEFAULT_EMAIL: z.string().email(),
+  KINGVALE_EMAIL: z.string().email(),
+
+  // Example of environment variable with a default value if not set
+  OPER_GET_CURRENT_MSGS: z
+    .string()
+    .optional()
+    .transform((val) => val?.trim() || "CMS_Current_Messages"),
+
+  // TODO: implement rest of environment variables
+});
+
+const config = configSchema.parse(process.env);
+
+// You can now import config and use its type-checked environment variables
+// like config.SMTP_HOST instead of process.env.SMTP_HOST!
+export default config;
+
 export const OPER_GET_CURRENT_MSGS = "CMS_Current_Messages";
 export const OPER_NEW_CMS_MSGS = "CMS_New_Messages";
 export const OPER_CLEAR_CMS_MSGS = "CMS_Clear_Messages";


### PR DESCRIPTION
Hey Arthi, I am using this package named `zod` to parse `process.env` so that any environment variables are type-checked before we use them. With zod, you define a "schema" which represents an object that you would like to parse and type-check, and then if the object passes the check then you will know in the rest of your code that it is all correctly typed.

In this case, the object we are parsing is `process.env`, and we define the environment variables that we expect `process.env` to have along with certain checks we would like to do on each variable (e.g., check that the variable not an empty string, or check that the variable is numeric). We can also do transforms on the environment variables so that if they are empty or just blank strings, we can set default values for them.

Zod can also be used for checking API responses to make sure that the object returned by the API is what you expected. For example, in the future, we could make sure that the ActiveITS XML API responses all exactly match the format that we expect instead of assuming the response type.

For more info on zod, check out their docs: https://zod.dev/